### PR TITLE
Avoid duplicate names between variables, auxiliary variables, and functions

### DIFF
--- a/HH-Vext.ode
+++ b/HH-Vext.ode
@@ -21,11 +21,11 @@ bh(v)=1/( 1+ exp(-(v+35)/10) )
 an(v)=0.01*(v+55)/(1-exp(-(V + 55)/10))
 bn(v)=0.125*exp(-(V+65)/80)
 
-vex(t)=vext*(sin(2*pi*(freq/1000)*t))
-ik=gk*n^4*(v+vex(t)-vk)
-ina=gna*m^3*h*(v+vex(t)-vna)
-il=gl*(v+vex(t)-vl)
-itrp=gtrp*(v+vex(t)-vtrp)
+f_vex(t)=vext*(sin(2*pi*(freq/1000)*t))
+ik=gk*n^4*(v+f_vex(t)-vk)
+ina=gna*m^3*h*(v+f_vex(t)-vna)
+il=gl*(v+f_vex(t)-vl)
+itrp=gtrp*(v+f_vex(t)-vtrp)
 
 # the equations
 v'=(-ik-ina-il-itrp+iapp)/cm
@@ -33,8 +33,7 @@ m'=(am(v)*(1-m)-bm(v)*m)
 n'=(an(v)*(1-n)-bn(v)*n)
 h'=(ah(v)*(1-h)-bh(v)*h)
 
-aux vex=vex(t)
-aux itrp=itrp
+aux vex=f_vex(t)
 
 # set xpp parameters
 @ total=10000, xp=t, yp=v, xlo=0, xhi=10000, ylo=-90, yhi=50, bounds=10000000, dt=0.01


### PR DESCRIPTION
XPP raises warnings
```
VEX is a duplicate name
ITRP is a duplicate name
```